### PR TITLE
Добавлен блок доверия под CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -3198,7 +3198,32 @@
             transform: scale(1.2);
             color: #ff6b35;
         }
-        
+
+        /* Trust block */
+        .trust-block {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+            gap: 20px;
+            margin-top: 30px;
+        }
+
+        .trust-block-item {
+            text-align: center;
+            opacity: 0.8;
+            transition: transform 0.3s ease, opacity 0.3s ease;
+        }
+
+        .trust-block-item:hover {
+            opacity: 1;
+            transform: scale(1.05);
+        }
+
+        @media (max-width: 576px) {
+            .trust-block {
+                display: none;
+            }
+        }
+
         .hero-features {
             position: relative;
             margin-top: 60px;
@@ -6402,7 +6427,26 @@
                         </div>
                     </a>
                 </div>
-                
+
+                <div class="trust-block">
+                    <div class="trust-block-item">
+                        <i class="fas fa-briefcase"></i>
+                        <span>10+ лет на рынке</span>
+                    </div>
+                    <div class="trust-block-item">
+                        <i class="fas fa-project-diagram"></i>
+                        <span>50+ реализованных проектов</span>
+                    </div>
+                    <div class="trust-block-item">
+                        <i class="fas fa-users"></i>
+                        <span>100+ довольных клиентов</span>
+                    </div>
+                    <div class="trust-block-item">
+                        <i class="fas fa-award"></i>
+                        <span>Сертифицированные специалисты</span>
+                    </div>
+                </div>
+
                 <!-- Trust indicators -->
                 <div class="hero-trust" itemscope itemtype="https://schema.org/Organization">
                     <meta itemprop="name" content="Доверие клиентов">


### PR DESCRIPTION
## Описание
- добавлен блок `.trust-block` с логотипами и статистикой под CTA-кнопками
- стилизован `.trust-block` с сеткой, полупрозрачностью и эффектом наведения

## Тестирование
- `npm test` (ошибка: не найден `package.json`)


------
https://chatgpt.com/codex/tasks/task_e_68af3b4a3ad08321aec8df2e788661cc